### PR TITLE
Refactor/attackby/afterattack-to-use_distant

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -148,7 +148,8 @@
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
-		if(A.Adjacent(src)) // see adjacent.dm
+		var/adjacent = A.Adjacent(src)
+		if (adjacent) // see adjacent.dm
 			if(W)
 				// Return TRUE in resolve_attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = W.resolve_attackby(A,src, modifiers)
@@ -163,7 +164,8 @@
 			return
 		else // non-adjacent click
 			if(W)
-				W.afterattack(A, src, 0, modifiers) // 0: not Adjacent
+				if (!W.use_on_distant(A, src, modifiers, FALSE) && !A.use_distant(W, src, modifiers, FALSE))
+					W.afterattack(A, src, 0, modifiers) // 0: not Adjacent
 			else
 				RangedAttack(A, modifiers)
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -63,6 +63,12 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		use_call = "use"
 		. = use_after(atom, user, click_params)
 	if (!.)
+		use_call = "distant item"
+		. = use_on_distant(atom, user, click_params, TRUE)
+	if (!.)
+		use_call = "distant"
+		. = atom.use_distant(src, user, click_params, TRUE)
+	if (!.)
 		use_call = null
 	atom.post_use_item(src, user, ., use_call, click_params)
 
@@ -377,7 +383,28 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 	return ..()
 
+
 /**
+ * Interaction handler for using an item on this atom while not adjacent, or if all other `resolve_attackby()` checks
+ * return `FALSE`.
+ *
+ * This is resolved after `/obj/item/proc/use_on_distant()`.
+ *
+ * **Parameters**:
+ * - `tool` - The item being used on this atom.
+ * - `user` - The mob interacting with this atom.
+ * - `click_params` - List of click parameters.
+ * - `adjacent` (Boolean) - Whether or not `src` is adjacent to `user`.
+ *
+ * Returns boolean to indicate whether the interaction was handled or not.
+ */
+/atom/proc/use_distant(obj/item/tool, mob/user, list/click_params, adjacent)
+	return FALSE
+
+
+/**
+ * **DEPRECATED. See `/obj/item/proc/use_on_distant()` and `/atom/proc/use_distant()` instead.**
+ *
  * Called when the item is in the active hand and another atom is clicked and `resolve_attackby()` returns FALSE. This is generally called by `ClickOn()`.
  * Works on ranged targets, unlike resolve_attackby()
  *
@@ -422,6 +449,26 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * * - `click_parameters` - List of click parameters. See BYOND's `Click()` documentation.
  */
 /obj/item/proc/use_before(atom/target, mob/living/user, click_parameters)
+	return FALSE
+
+
+/**
+ * Called when an atom is clicked while the item is in the active hand. This is called on click on one of the following
+ * conditions:
+ * - `target` is adjacent and `user.resolve_attackby()` otherwise returns `FALSE`.
+ * - `target` is not adjacent.
+ *
+ * This is resolved before `/atom/proc/use_distant()`.
+ *
+ * **Parameters**:
+ * - `target` - The atom that was clicked.
+ * - `user` - The mob that clicked the target.
+ * - `click_params` - List of click parameters. See BYOND's `Click()` documentation.
+ * - `adjacent` (Boolean) - Whether or not `target` is adjacent to `user`.
+ *
+ * Returns boolen to indicate whether the use call was handled or not.
+ */
+/obj/item/proc/use_on_distant(atom/target, mob/living/user, list/click_params, adjacent)
 	return FALSE
 
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -58,6 +58,7 @@ exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
 exactly 12 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 31 "afterattack() override - Use \`use_distant()\` or \`use_on_distant()\` instead" '\/afterattack\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
No user facing changes.

Adds `use_distant()` and `use_on_distant()` procs on `/atom` and `/obj/item`, respectively, intended to eventually replace most if not all of the current `afterattack()` calls, similar to the recent replacement of `attackby()`.

New procs are called in relevant places by `resolve_attackby()` and `ClickOn()` prior to considering `afterattack()`.

Also added a test to fail on any new `afterattack()` overrides.

No implementations in this PR - That will come in separate PRs.